### PR TITLE
Fix BioMime latent vector resampling in dynamic contractions

### DIFF
--- a/src/muniverse/data_generation/_run_neuromotion.py
+++ b/src/muniverse/data_generation/_run_neuromotion.py
@@ -838,6 +838,15 @@ def generate_muaps(
     print(f"Starting simulation with {num_mus} motor units, {steps} movement steps")
     start_time = time.time()
 
+    # Sample latent vectors once so each MU keeps a consistent identity across
+    # all movement steps.  Previously zi was resampled every step, causing the
+    # MUAP morphology to jump randomly instead of evolving smoothly with the
+    # changing biomechanical conditions.
+    if not morph:
+        zi = torch.randn(num_mus, model_config.Model.Generator.Latent)
+        if device == "cuda":
+            zi = zi.cuda()
+
     muaps = []
     for sp in tqdm(
         range(steps),
@@ -854,13 +863,8 @@ def generate_muaps(
                 length[:, sp] * ch_len.iloc[sp, :].values,
             )
         ).transpose(1, 0)
-        if not morph:
-            zi = torch.randn(num_mus, model_config.Model.Generator.Latent)
-            if device == "cuda":
-                zi = zi.cuda()
-        else:
-            if device == "cuda":
-                base_muaps = base_muaps.cuda()
+        if morph and device == "cuda":
+            base_muaps = base_muaps.cuda()
 
         if device == "cuda":
             cond = cond.cuda()


### PR DESCRIPTION
Fixed the zi, resampling bug. MUAPs in dynamic contractions would be generated with random zi latent biomime vectors.

Images corroborate the bug fix


<img width="1188" height="446" alt="Screenshot 2026-03-17 at 23 01 11" src="https://github.com/user-attachments/assets/19178c66-8e14-4b87-8fe5-57a00b1e45b8" />
<img width="1569" height="677" alt="Screenshot 2026-03-17 at 23 01 00" src="https://github.com/user-attachments/assets/67e69e62-1932-4f96-86dd-7f11ff547977" />
